### PR TITLE
cor-asv-ann-eval CLI: --help == -h

### DIFF
--- a/ocrd_cor_asv_ann/scripts/eval.py
+++ b/ocrd_cor_asv_ann/scripts/eval.py
@@ -5,7 +5,9 @@ import click
 
 from ..lib.seq2seq import Sequence2Sequence
 
-@click.command()
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
+@click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('-m', '--load-model', default="model.h5", help='model file to load',
               type=click.Path(dir_okay=False, exists=True))
 # click.File is impossible since we do not now a priori whether


### PR DESCRIPTION
To avoid

```
Usage: cor-asv-ann-eval [OPTIONS] [DATA]...
Try 'cor-asv-ann-eval --help' for help.

Error: No such option: -h
Usage: cor-asv-ann-eval [OPTIONS] [DATA]...
Try 'cor-asv-ann-eval --help' for help.

Error: No such option: -h
Makefile:647: recipe for target '/usr/bin/cor-asv-ann-eval-check' failed
make: *** [/usr/bin/cor-asv-ann-eval-check] Error 2
```

error on `make check` in ocrd_all